### PR TITLE
Add live theme switcher in todo demo

### DIFF
--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use catppuccin_egui::{FRAPPE, LATTE, MACCHIATO, MOCHA};
 use eframe::egui;
 
 fn main() {
@@ -18,6 +19,15 @@ struct App {
     todos: Vec<Todo>,
     new_todo: String,
     mode: Mode,
+    theme: CatppuccinTheme,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CatppuccinTheme {
+    Frappe,
+    Latte,
+    Macchiato,
+    Mocha,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -76,13 +86,22 @@ impl Default for App {
                 .collect(),
             new_todo: String::new(),
             mode: Mode::default(),
+            theme: CatppuccinTheme::Mocha,
         }
     }
 }
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        catppuccin_egui::set_theme(ctx, catppuccin_egui::MOCHA);
+        catppuccin_egui::set_theme(
+            ctx,
+            match self.theme {
+                CatppuccinTheme::Frappe => FRAPPE,
+                CatppuccinTheme::Latte => LATTE,
+                CatppuccinTheme::Macchiato => MACCHIATO,
+                CatppuccinTheme::Mocha => MOCHA,
+            },
+        );
         ctx.set_pixels_per_point(1.25);
 
         let mut fonts = egui::FontDefinitions::default();
@@ -98,7 +117,17 @@ impl eframe::App for App {
         ctx.set_fonts(fonts);
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("Todos");
+            ui.horizontal(|ui| {
+                ui.heading("Todos");
+                egui::ComboBox::from_label("")
+                    .selected_text(format!("{:?}", self.theme))
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Latte, "Latte");
+                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Frappe, "Frappe");
+                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Macchiato, "Macchiato");
+                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Mocha, "Mocha");
+                    });
+            });
             ui.horizontal(|ui| {
                 if ui.text_edit_singleline(&mut self.new_todo).lost_focus()
                     && !self.new_todo.is_empty()

--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -117,17 +117,24 @@ impl eframe::App for App {
         ctx.set_fonts(fonts);
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.heading("Todos");
-                egui::ComboBox::from_label("")
-                    .selected_text(format!("{:?}", self.theme))
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Latte, "Latte");
-                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Frappe, "Frappe");
-                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Macchiato, "Macchiato");
-                        ui.selectable_value(&mut self.theme, CatppuccinTheme::Mocha, "Mocha");
-                    });
+            ui.columns(2, |columns| {
+                columns[0].heading("Todos");
+                columns[1].with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                    egui::ComboBox::from_label("")
+                        .selected_text(format!("{:?}", self.theme))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut self.theme, CatppuccinTheme::Latte, "Latte");
+                            ui.selectable_value(&mut self.theme, CatppuccinTheme::Frappe, "Frappe");
+                            ui.selectable_value(
+                                &mut self.theme,
+                                CatppuccinTheme::Macchiato,
+                                "Macchiato",
+                            );
+                            ui.selectable_value(&mut self.theme, CatppuccinTheme::Mocha, "Mocha");
+                        });
+                });
             });
+
             ui.horizontal(|ui| {
                 if ui.text_edit_singleline(&mut self.new_todo).lost_focus()
                     && !self.new_todo.is_empty()
@@ -140,6 +147,7 @@ impl eframe::App for App {
                     self.new_todo.clear();
                 }
             });
+
             ui.separator();
 
             egui::ScrollArea::vertical()


### PR DESCRIPTION
![2023-04-26T15:30:15,070921679-06:00](https://user-images.githubusercontent.com/45475651/234707695-84e2b790-34dc-4c25-9b4f-55f170e50022.png)

![2023-04-26T15:32:34,299510166-06:00](https://user-images.githubusercontent.com/45475651/234707788-09fecd35-f0d5-403b-b5cd-8bf96436f898.png)


This PR adds a simple combo box for the todo demo which lets you switch between themes to see which looks best 😃. It helps users preview the different themes on their system without recompiling, which I think is an important feature for the themed example.