### PR TITLE
Update egui dependency to 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.2](https://github.com/catppuccin/egui/compare/v2.0.1...v2.0.2) (2023-05-25)
+
+* Bump egui version to 0.22
+
 ## [2.0.1](https://github.com/catppuccin/egui/compare/v2.0.0...v2.0.1) (2023-03-24)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catppuccin-egui"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Sam Nystrom <sam@samnystrom.dev>"]
 edition = "2021"
 description = "Soothing pastel theme for egui."
@@ -14,7 +14,7 @@ categories = ["gui"]
 exclude = ["assets/"]
 
 [dependencies]
-egui = "0.21"
+egui = "0.22"
 
 [dev-dependencies]
-eframe = "0.21"
+eframe = "0.22"


### PR DESCRIPTION
Hello, made a quick fork and updated the egui version to 0.22.
Also tested the todo app, still runs, so there were no breaking changes.