### PR TITLE
Update eframe and egui requirement from 0.23 to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 exclude = ["assets/"]
 
 [dependencies]
-egui = "0.23"
+egui = "0.24"
 
 [dev-dependencies]
-eframe = "0.23"
+eframe = "0.24"


### PR DESCRIPTION
_Type mismatch [E0308] expected `&Context`, but found `&Context`_ 
caused by the mismatch version of egui and eframe with the latest release of egui and eframe 0.24