### PR TITLE
cargo-release: update README version

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,3 @@
+pre-release-replacements = [
+    { file="README.md", search="catppuccin-egui = .*", replace="{{crate_name}} = \"^{{version}}\"" }
+]


### PR DESCRIPTION
As per #26, this PR makes `cargo release replace` (or `cargo release`) replace the version number in the README.

```
❯ cargo release replace
   Replacing in README.md
--- README.md   original
+++ README.md   replaced
@@ -49 +49 @@
-catppuccin-egui = "4.0"
+catppuccin-egui = "^4.0.0"

warning: aborting release due to dry run; re-run with `--execute`
```

I didn't check how this fits in with your existing release workflow. `cargo-release` is capable of pretty much everything a normal crate needs, so I'm not sure where you want to take this idea.