### PR TITLE
Update egui to v0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 exclude = ["assets/"]
 
 [dependencies]
-egui = "0.25"
+egui = "0.26"
 
 [dev-dependencies]
-eframe = "0.25"
+eframe = "0.26"


### PR DESCRIPTION
I was surprised to see no errors - seems like #29 and #30 only cause problems in isolation.

- compiles
- tests pass
- example works
- clippy has no complaints

closes #29, closes #30