### PR TITLE
fix: remove widget border from style

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,6 @@ fn make_widget_visual(
     style::WidgetVisuals {
         bg_fill,
         weak_bg_fill: bg_fill,
-        bg_stroke: egui::Stroke {
-            color: theme.overlay1,
-            ..old.bg_stroke
-        },
         fg_stroke: egui::Stroke {
             color: theme.text,
             ..old.fg_stroke


### PR DESCRIPTION
The border isn't antialiased for some reason, so removing it seems to be the best option.