### PR TITLE
chore(deps): disable Renovate PRs for `egui`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>catppuccin/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["egui"],
+      "prCreation": "approval"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["egui"],
-      "prCreation": "approval"
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Renovate is creating PRs for the aliased egui dependencies ([for example](https://github.com/catppuccin/egui/pull/84/files)), which are used for backwards compatibility, so updating them to the latest version is an unwanted update that would cause issues if unintentionally merged.

This repo has never had any of the Renovate egui PRs merged, this PR disables the PR creation for egui dependencies until they are approved by a maintainer via the dependency dashboard (unlikely but still provides notification updates for new egui versions).

Validated using renovate-config-validator
```
 INFO: Validating renovate.json
 INFO: Config validated successfully
```
