### PR TITLE
chore: upgrade todo app dependencies

### DIFF
--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -6,5 +6,5 @@ license = "MIT"
 publish = false
 
 [dependencies]
-eframe = "0.31"
-catppuccin-egui = { version = "5.5", default-features = false, features = ["egui31"] }
+eframe = "0.32"
+catppuccin-egui = { version = "5.6", default-features = false, features = ["egui32"] }

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -6,5 +6,5 @@ license = "MIT"
 publish = false
 
 [dependencies]
-eframe = "0.29"
-catppuccin-egui = { version = "5.3", default-features = false, features = ["egui29"] }
+eframe = "0.31"
+catppuccin-egui = { version = "5.5", default-features = false, features = ["egui31"] }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -102,12 +102,13 @@ impl eframe::App for App {
                 CatppuccinTheme::Mocha => MOCHA,
             },
         );
-        ctx.set_pixels_per_point(1.25);
 
         let mut fonts = egui::FontDefinitions::default();
         fonts.font_data.insert(
             "open-sans".to_string(),
-            egui::FontData::from_static(include_bytes!("./OpenSans-Regular.ttf")),
+            std::sync::Arc::new(egui::FontData::from_static(include_bytes!(
+                "./OpenSans-Regular.ttf"
+            ))),
         );
         fonts
             .families


### PR DESCRIPTION
This PR upgrades the eframe version and egui feature version to the latest available for the TODO example app.
To adapt it to work with the newest egui version, it uses an arc for the font definition, because of [this change in 0.30](https://github.com/emilk/egui/pull/5276)
It also removes the `set_pixels_per_point` call as it made the font impossibly small on macos at least, happy to change that back if needed but I couldn't use the example as it was 😅 

