### PR TITLE
feat: add egui 0.32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ egui28 = { version = "0.28", package = "egui", default-features = false, optiona
 egui29 = { version = "0.29", package = "egui", default-features = false, optional = true }
 egui30 = { version = "0.30", package = "egui", default-features = false, optional = true }
 egui31 = { version = "0.31", package = "egui", default-features = false, optional = true }
+egui32 = { version = "0.32", package = "egui", default-features = false, optional = true }
 
 [dev-dependencies]
 eframe = "0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,8 @@
     feature = "egui28",
     feature = "egui29",
     feature = "egui30",
-    feature = "egui31"
+    feature = "egui31",
+    feature = "egui32",
 )))]
 compile_error!("at least one egui version must be enabled");
 
@@ -52,6 +53,8 @@ use egui29 as egui;
 use egui30 as egui;
 #[cfg(feature = "egui31")]
 use egui31 as egui;
+#[cfg(feature = "egui32")]
+use egui32 as egui;
 
 use egui::{epaint, style};
 


### PR DESCRIPTION
This PR makes the necessary changes to allow for egui v0.32, nothing unique here as it's a typical set of changes.
Tested against an egui project running 0.32.