### PR TITLE
feat: add egui 0.34 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ egui30 = { version = "0.30", package = "egui", default-features = false, optiona
 egui31 = { version = "0.31", package = "egui", default-features = false, optional = true }
 egui32 = { version = "0.32", package = "egui", default-features = false, optional = true }
 egui33 = { version = "0.33", package = "egui", default-features = false, optional = true }
+egui34 = { version = "0.34", package = "egui", default-features = false, optional = true }
 
 [dev-dependencies]
 eframe = "0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,12 @@ pub use themes::*;
 
 /// Apply the given theme to a [`Context`](egui::Context).
 pub fn set_theme(ctx: &egui::Context, theme: Theme) {
+    #[cfg(feature = "egui34")]
+    let old = ctx.global_style().visuals.clone();
+
+    #[cfg(not(feature = "egui34"))]
     let old = ctx.style().visuals.clone();
+
     ctx.set_visuals(theme.visuals(old));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
     feature = "egui31",
     feature = "egui32",
     feature = "egui33",
+    feature = "egui34",
 )))]
 compile_error!("at least one egui version must be enabled");
 
@@ -58,6 +59,8 @@ use egui31 as egui;
 use egui32 as egui;
 #[cfg(feature = "egui33")]
 use egui33 as egui;
+#[cfg(feature = "egui34")]
+use egui34 as egui;
 
 use egui::{epaint, style};
 


### PR DESCRIPTION
This PR is very similar to #96. I tested it by modifying the todo example, but didn't commit those changes for the same reason @philpax didn't last time.

```diff
diff --git i/examples/todo/Cargo.toml w/examples/todo/Cargo.toml
index d760563..aa657d8 100644
--- i/examples/todo/Cargo.toml
+++ w/examples/todo/Cargo.toml
@@ -6,5 +6,5 @@ license = "MIT"
 publish = false
 
 [dependencies]
-eframe = "0.32"
-catppuccin-egui = { version = "5.6", default-features = false, features = ["egui32"] }
+eframe = "0.34"
+catppuccin-egui = { path = "../..", default-features = false, features = ["egui34"] }
diff --git i/examples/todo/src/main.rs w/examples/todo/src/main.rs
index 741dd7b..b2da31d 100644
--- i/examples/todo/src/main.rs
+++ w/examples/todo/src/main.rs
@@ -4,6 +4,7 @@
 
 use catppuccin_egui::{FRAPPE, LATTE, MACCHIATO, MOCHA};
 use eframe::egui;
+use eframe::egui::Ui;
 
 fn main() {
     let native_options = eframe::NativeOptions::default();
@@ -92,7 +93,7 @@ impl Default for App {
 }
 
 impl eframe::App for App {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ctx: &mut Ui, _frame: &mut eframe::Frame) {
         catppuccin_egui::set_theme(
             ctx,
             match self.theme {

```

---

I've also updated `lib.rs` to avoid a deprecation warning on `Context::style`:

```diff
diff --git c/src/lib.rs w/src/lib.rs
index be38f38..3fc7816 100644
--- c/src/lib.rs
+++ w/src/lib.rs
@@ -69,7 +69,12 @@ pub use themes::*;
 
 /// Apply the given theme to a [`Context`](egui::Context).
 pub fn set_theme(ctx: &egui::Context, theme: Theme) {
+    #[cfg(feature = "egui34")]
+    let old = ctx.global_style().visuals.clone();
+
+    #[cfg(not(feature = "egui34"))]
     let old = ctx.style().visuals.clone();
+
     ctx.set_visuals(theme.visuals(old));
 }
```